### PR TITLE
fix: make rebuild command drive unify_builder rebuild mode

### DIFF
--- a/runtime/python/eide_rebuild/executor.py
+++ b/runtime/python/eide_rebuild/executor.py
@@ -64,6 +64,7 @@ def build_unify_builder_command(dotnet_path: str, unify_builder_path: str, build
         unify_builder_dll,
         "-p",
         builder_params_path,
+        "--rebuild",
     ]
 
 

--- a/runtime/tests/test_eide_rebuild.py
+++ b/runtime/tests/test_eide_rebuild.py
@@ -858,6 +858,7 @@ class ExecutorTests(unittest.TestCase):
                 dll_path.resolve().as_posix(),
                 "-p",
                 "D:/repo/build/Debug/builder.params",
+                "--rebuild",
             ],
         )
 
@@ -920,7 +921,7 @@ targets:
                     "           FLASH:      139076 B       180 KB     75.45%\n"
                 ),
                 stderr="",
-                command=["dotnet", "unify_builder.dll", "-p", "build/Debug/builder.params"],
+                command=["dotnet", "unify_builder.dll", "-p", "build/Debug/builder.params", "--rebuild"],
                 cwd=project_dir.as_posix(),
             )
 
@@ -986,7 +987,7 @@ targets:
                 duration_ms=1000,
                 stdout="",
                 stderr="",
-                command=["dotnet", "unify_builder.dll", "-p", "build/Debug/builder.params"],
+                command=["dotnet", "unify_builder.dll", "-p", "build/Debug/builder.params", "--rebuild"],
                 cwd=project_dir.as_posix(),
             )
 

--- a/skills/eide-rebuild/scripts/eide_rebuild/executor.py
+++ b/skills/eide-rebuild/scripts/eide_rebuild/executor.py
@@ -64,6 +64,7 @@ def build_unify_builder_command(dotnet_path: str, unify_builder_path: str, build
         unify_builder_dll,
         "-p",
         builder_params_path,
+        "--rebuild",
     ]
 
 


### PR DESCRIPTION
## Summary

- add `--rebuild` to the direct `unify_builder` command used by `eide_rebuild.py rebuild`
- align runner behavior with local EIDE `Rebuild`, so the builder transcript enters rebuild mode instead of incremental mode
- update executor tests to assert the rebuild flag is present

## Validation

- [ ] Built the bridge VSIX
- [x] Synced the skill bundle
- [x] Ran unit tests
- [ ] Checked that examples stay sanitized

## Issue

Fixes #2

## Real verification

- real repo rebuild: `D:\Git_ECU\CICD\BF_ECU_AppSwPrjtGen3_GD32F503_Y26M02`
- observed command includes `--rebuild`
- observed transcript line: `[ INFO ] file statistics (rebuild mode)`
