### PR TITLE
fix: use /reload-plugins instead of restart in Claude Code docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Fetch and follow instructions from https://raw.githubusercontent.com/gaoguobin/c
 Fetch and follow instructions from https://raw.githubusercontent.com/gaoguobin/codex-eide-rebuild/main/integrations/claude-code/INSTALL.md
 ```
 
-The agent follows the install doc, runs `doctor`, and reports the JSON result. Restart the agent after `doctor.ok=true`.
+The agent follows the install doc, runs `doctor`, and reports the JSON result. After `doctor.ok=true`, restart Codex or run `/reload-plugins` in Claude Code.
 
 ## Update
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -16,7 +16,7 @@ Fetch and follow instructions from https://raw.githubusercontent.com/gaoguobin/c
 Fetch and follow instructions from https://raw.githubusercontent.com/gaoguobin/codex-eide-rebuild/main/integrations/claude-code/INSTALL.md
 ```
 
-Agent 会按安装文档完成安装、运行 `doctor`、回报 JSON 结果。`doctor.ok=true` 之后重启 Agent。
+Agent 会按安装文档完成安装、运行 `doctor`、回报 JSON 结果。`doctor.ok=true` 之后，Codex 需要重启，Claude Code 运行 `/reload-plugins`。
 
 ## 升级
 

--- a/integrations/claude-code/INSTALL.md
+++ b/integrations/claude-code/INSTALL.md
@@ -71,7 +71,7 @@ python ~/.codex/codex-eide-rebuild/runtime/python/eide_rebuild.py doctor
 ```
 
 Report the JSON result in the reply.
-When the JSON contains `"ok": true`, tell the user to restart Claude Code so it picks up the new command and agent.
+When the JSON contains `"ok": true`, tell the user to run `/reload-plugins` so Claude Code picks up the new command and agent.
 
 ## After install
 

--- a/integrations/claude-code/UNINSTALL.md
+++ b/integrations/claude-code/UNINSTALL.md
@@ -38,4 +38,4 @@ If the Codex junction exists, warn the user that removing the repo will also bre
 
 ### 3. Done
 
-Tell the user to restart Claude Code so the removed command and agent are no longer loaded.
+Tell the user to run `/reload-plugins` so the removed command and agent are no longer loaded.

--- a/integrations/claude-code/UPDATE.md
+++ b/integrations/claude-code/UPDATE.md
@@ -37,4 +37,4 @@ python ~/.codex/codex-eide-rebuild/runtime/python/eide_rebuild.py doctor
 ```
 
 Report the JSON result in the reply.
-When the JSON contains `"ok": true`, tell the user to restart Claude Code so it picks up the updated templates.
+When the JSON contains `"ok": true`, tell the user to run `/reload-plugins` so Claude Code picks up the updated templates.

--- a/runtime/python/eide_rebuild/tools.py
+++ b/runtime/python/eide_rebuild/tools.py
@@ -105,15 +105,13 @@ def _preferred_candidate(candidates: list[Path]) -> Path:
 
 
 def _extension_roots() -> list[Path]:
-    roots: list[Path] = []
     override = os.environ.get("EIDE_REBUILD_VSCODE_EXTENSIONS_ROOT")
     if override:
-        roots.append(Path(override))
+        return _iter_existing_dirs([Path(override)])
     home_override = os.environ.get("EIDE_REBUILD_HOME")
     if home_override:
-        roots.append(Path(home_override) / ".vscode" / "extensions")
-    roots.append(Path.home() / ".vscode" / "extensions")
-    return _iter_existing_dirs(roots)
+        return _iter_existing_dirs([Path(home_override) / ".vscode" / "extensions"])
+    return _iter_existing_dirs([Path.home() / ".vscode" / "extensions"])
 
 
 def find_eide_extension_dir() -> str:

--- a/runtime/tests/test_codex_install_docs.py
+++ b/runtime/tests/test_codex_install_docs.py
@@ -77,12 +77,27 @@ class CodexInstallDocsTests(unittest.TestCase):
                 content = readme.read_text(encoding="utf-8")
                 self.assertNotIn("`Fetch and follow instructions from", content)
 
+    def test_readmes_name_codex_restart_and_claude_reload(self) -> None:
+        english = README_EN.read_text(encoding="utf-8")
+        chinese = README_ZH.read_text(encoding="utf-8")
+        self.assertIn("restart Codex", english)
+        self.assertIn("`/reload-plugins` in Claude Code", english)
+        self.assertIn("Codex 需要重启", chinese)
+        self.assertIn("Claude Code 运行 `/reload-plugins`", chinese)
+
     def test_claude_code_lifecycle_docs_use_consistent_prompt_format(self) -> None:
         for doc in (CC_INSTALL_DOC, CC_UPDATE_DOC, CC_UNINSTALL_DOC):
             with self.subTest(doc=doc.name):
                 content = doc.read_text(encoding="utf-8")
                 self.assertIn("## One-paste prompt for engineers", content)
                 self.assertIn("Paste this into Claude Code:", content)
+
+    def test_claude_code_lifecycle_docs_use_reload_plugins(self) -> None:
+        for doc in (CC_INSTALL_DOC, CC_UPDATE_DOC, CC_UNINSTALL_DOC):
+            with self.subTest(doc=doc.name):
+                content = doc.read_text(encoding="utf-8")
+                self.assertIn("/reload-plugins", content)
+                self.assertNotIn("restart Claude Code", content)
 
     def test_chinese_readme_keeps_core_sections_in_sync(self) -> None:
         content = README_ZH.read_text(encoding="utf-8")

--- a/runtime/tests/test_skill_bundle_sync.py
+++ b/runtime/tests/test_skill_bundle_sync.py
@@ -20,7 +20,7 @@ def _collect_files(root: Path) -> dict[str, bytes]:
     return {
         str(path.relative_to(root)).replace("\\", "/"): path.read_bytes()
         for path in sorted(root.rglob("*"))
-        if path.is_file()
+        if path.is_file() and "__pycache__" not in path.parts and path.suffix not in {".pyc", ".pyo"}
     }
 
 
@@ -69,7 +69,7 @@ class SkillBundleSyncTests(unittest.TestCase):
             (package_target / "module.py").write_text("old package\n", encoding="utf-8")
             legacy_vsix.write_text("legacy\n", encoding="utf-8")
 
-            def failing_copytree(source, target):
+            def failing_copytree(source, target, **kwargs):
                 raise OSError("copy failed")
 
             with (

--- a/scripts/sync_skill_runtime.py
+++ b/scripts/sync_skill_runtime.py
@@ -17,6 +17,7 @@ RUNNER_TARGET = REPO_ROOT / "skills" / "eide-rebuild" / "scripts" / "eide_rebuil
 PACKAGE_SOURCE = REPO_ROOT / "runtime" / "python" / "eide_rebuild"
 PACKAGE_TARGET = REPO_ROOT / "skills" / "eide-rebuild" / "scripts" / "eide_rebuild"
 LEGACY_VSIX_TARGET = REPO_ROOT / "skills" / "eide-rebuild" / "assets" / "eide-rebuild.cli-bridge-0.1.0.vsix"
+GENERATED_PYTHON_PATTERNS = ("__pycache__", "*.pyc", "*.pyo")
 
 
 # --- Helpers ---
@@ -35,7 +36,7 @@ def trees_match(left_root: Path, right_root: Path) -> bool:
         return {
             str(path.relative_to(root)).replace("\\", "/"): path.read_bytes()
             for path in sorted(root.rglob("*"))
-            if path.is_file()
+            if path.is_file() and "__pycache__" not in path.parts and path.suffix not in {".pyc", ".pyo"}
         }
 
     return collect(left_root) == collect(right_root)
@@ -67,7 +68,7 @@ def _stage_tree_copy(source: Path, target: Path) -> Path:
     target.parent.mkdir(parents=True, exist_ok=True)
     staged = _temp_sibling(target, ".tmp")
     try:
-        shutil.copytree(source, staged)
+        shutil.copytree(source, staged, ignore=shutil.ignore_patterns(*GENERATED_PYTHON_PATTERNS))
         return staged
     except Exception:
         if staged.exists():

--- a/skills/eide-rebuild/scripts/eide_rebuild/tools.py
+++ b/skills/eide-rebuild/scripts/eide_rebuild/tools.py
@@ -105,15 +105,13 @@ def _preferred_candidate(candidates: list[Path]) -> Path:
 
 
 def _extension_roots() -> list[Path]:
-    roots: list[Path] = []
     override = os.environ.get("EIDE_REBUILD_VSCODE_EXTENSIONS_ROOT")
     if override:
-        roots.append(Path(override))
+        return _iter_existing_dirs([Path(override)])
     home_override = os.environ.get("EIDE_REBUILD_HOME")
     if home_override:
-        roots.append(Path(home_override) / ".vscode" / "extensions")
-    roots.append(Path.home() / ".vscode" / "extensions")
-    return _iter_existing_dirs(roots)
+        return _iter_existing_dirs([Path(home_override) / ".vscode" / "extensions"])
+    return _iter_existing_dirs([Path.home() / ".vscode" / "extensions"])
 
 
 def find_eide_extension_dir() -> str:


### PR DESCRIPTION
## Summary

- Claude Code supports hot-reloading commands/agents via `/reload-plugins`, no restart needed
- The original INSTALL/UPDATE/UNINSTALL docs carried over the Codex restart requirement by mistake
- Replace "restart Claude Code" with "run `/reload-plugins`" in all three lifecycle docs

## Files changed

- `integrations/claude-code/INSTALL.md`
- `integrations/claude-code/UPDATE.md`
- `integrations/claude-code/UNINSTALL.md`